### PR TITLE
Fix dividers underneath video sections

### DIFF
--- a/src/pages/Videos.jsx
+++ b/src/pages/Videos.jsx
@@ -82,7 +82,7 @@ const Videos = () => {
         
 
         <PageStyles.Break />
-        {(index + 1 === c.videos.length) ? null : <><PageStyles.Divider /><PageStyles.Break /></>}
+        {((index + 1) === displayData.categories.length) ? null : <><PageStyles.Divider /><PageStyles.Break /></>}
 
       </React.Fragment>)}
 


### PR DESCRIPTION
- Fix issue with dividers not appearing underneath every video section, and appearing underneath the final section
- #4 